### PR TITLE
Create KS that identifies the number of sound sources

### DIFF
--- a/src/knowledge_sources/SourceNumberKS.m
+++ b/src/knowledge_sources/SourceNumberKS.m
@@ -1,10 +1,7 @@
 classdef SourceNumberKS < AuditoryFrontEndDepKS
     % SourceNumberKS predicts the number of perceived sources.
     %
-    % At the moment this is only a dummy implementation that will always return 5.
-    %
-    % In the long run most probably this function will compare two signals and judge which
-    % of the two has higher audio quality
+    % At the moment this is a dummy function and will always return 1.
 
     properties (SetAccess = private)
         auditoryFrontEndParameter;


### PR DESCRIPTION
There is already a `SourceNumberKS` present, but it has no functionality yet.

The desired outcome of this knowledge source should be to return the number of sound sources present in the given binaural input signal. In addition a score about its 
certainty would be a good idea.
