### PR TITLE
Easier ways to request data by knowledge sources

### DIFF
--- a/src/knowledge_sources/AuditoryFrontEndDepKS.m
+++ b/src/knowledge_sources/AuditoryFrontEndDepKS.m
@@ -5,6 +5,7 @@ classdef AuditoryFrontEndDepKS < AbstractKS
     properties (SetAccess = private)
         requests;       
         reqHashs;
+        lastBlockEnd;
     end
     
     %% -----------------------------------------------------------------------------------
@@ -15,6 +16,7 @@ classdef AuditoryFrontEndDepKS < AbstractKS
             obj.requests = requests;
             for ii = 1 : length( obj.requests )
                 obj.reqHashs{ii} = AuditoryFrontEndKS.getRequestHash( obj.requests{ii} );
+                obj.lastBlockEnd(ii) = 0;
             end
             %           example:
             %             requests{1}.name = 'modulation';
@@ -45,6 +47,40 @@ classdef AuditoryFrontEndDepKS < AbstractKS
             for ii = 1 : length( obj.requests )
                 afeSignals(ii) = obj.blackboard.signals(obj.reqHashs{ii});
             end
+        end
+        %% -------------------------------------------------------------------------------
+
+        function ens = hasEnoughNewSignal( obj, blockLen_s )
+            ens = all( obj.blackboard.currentSoundTimeIdx - obj.lastBlockEnd >= blockLen_s );
+        end
+        %% -------------------------------------------------------------------------------
+
+        function signalBlock = getSignalBlock( obj, sigId, blockTimes, padFront, padEnd )
+            signalStream = obj.blackboard.signals(obj.reqHashs{sigId});
+            backOffset = obj.blackboard.currentSoundTimeIdx - blockTimes(2);
+            if backOffset < 0
+                error( 'Requesting blocks ending in the future is not possible.' );
+            end
+            blockLen = blockTimes(2) - blockTimes(1);
+            signalBlock = signalStream.getSignalBlock( blockLen, backOffset, padFront );
+            if nargin >= 5 && padEnd
+                blocksize_samples = ceil( signalStream.FsHz * blockLen );
+                if (size( signalBlock, 1 ) < blocksize_samples)
+                    signalBlock = [signalBlock; ...
+                        zeros( blocksize_samples - size(signalBlock,1), ...
+                               size(signalBlock,2), size(signalBlock,3) )];
+                end
+            end
+            obj.lastBlockEnd(sigId) = blockTimes(2);
+        end
+        %% -------------------------------------------------------------------------------
+
+        function signalBlock = getNextSignalBlock( obj, sigId, blockLen_s, shift_s, padFront, padEnd )
+            if nargin < 4, shift_s = blockLen_s; end
+            if nargin < 5, padFront = true; end
+            if nargin < 6, padEnd = false; end
+            blockTimes = [obj.lastBlockEnd(sigId)+shift_s-blockLen_s obj.lastBlockEnd(sigId)+shift_s];
+            signalBlock = obj.getSignalBlock( sigId, blockTimes, padFront, padEnd );
         end
         %% -------------------------------------------------------------------------------
 

--- a/src/knowledge_sources/DnnLocationKS.m
+++ b/src/knowledge_sources/DnnLocationKS.m
@@ -47,7 +47,7 @@ classdef DnnLocationKS < AuditoryFrontEndDepKS
             requests{3}.params = param;
             obj = obj@AuditoryFrontEndDepKS(requests);
             obj.blockSize = 0.5;
-            obj.lastExecutionTime_s = 0;
+            obj.invocationMaxFrequency_Hz = 10;
 
             % Load localiastion DNNs
             obj.nChannels = nChannels;
@@ -77,17 +77,13 @@ classdef DnnLocationKS < AuditoryFrontEndDepKS
             
             % Execute KS if a sufficient amount of data for one block has
             % been gathered
-            bExecute = (obj.blackboard.currentSoundTimeIdx - ...
-                obj.lastExecutionTime_s) >= obj.blockSize;
+            bExecute = obj.hasEnoughNewSignal( obj.blockSize );
             bWait = false;
         end
 
         function execute(obj)
-            afeData = obj.getAFEdata();
-            ccSObj = afeData(1);
-            cc = ccSObj.getSignalBlock(obj.blockSize, obj.timeSinceTrigger);
-            ildSObj = afeData(2);
-            ild = ildSObj.getSignalBlock(obj.blockSize, obj.timeSinceTrigger);
+            cc = obj.getNextSignalBlock( 1, obj.blockSize, obj.blockSize, false );
+            ild = obj.getNextSignalBlock( 2, obj.blockSize, obj.blockSize, false );
 
             % Compute posterior distributions for each frequency channel and time frame
             nFrames = size(ild,1);


### PR DESCRIPTION
This was reported by @ningma97:

As we discussed, it'd be nice to have an easy means to request data of a certain length from the blackboard. Currently it's not straightforward to retrieve data from the end of the last processing block used by a KS but only since last triggering time. Therefore some data can be lost (as I just came to realise).

Suggestions:

Add a method such as "HasData(dataObject, duration_sec)" which returns true if there is enough data from the dataObject available from the end of the last processing block (used by the KS) rather than since last trigger time as currently implemented. This can be used in the CanExcute() method.
Add a method "GetData(dataObject, duration_sec)" in order to retrieve data of duration_sec long from dataObject, again from the end of the last processing block used by the KS. When not enough data is available, this method should give some warning and only return the actual amount of data, rather than padding zeros at the beginning, i.e. padding can be done outside the method if necessary, but the user needs to know how much data is retrieved.
This allows us to retrieve two half-second long blocks by a KS if we define a one-second long simulated signal, regardless the block size used by the binaural simulator (4096 samples at 44.1kHz).

I hope this is straightforward to implement, but it'd be really important.
