### PR TITLE
derive KSs with AMLTTP models from an intermediate base class

### DIFF
--- a/src/knowledge_sources/AbstractAMLTTPKS.m
+++ b/src/knowledge_sources/AbstractAMLTTPKS.m
@@ -7,7 +7,7 @@ classdef AbstractAMLTTPKS < AuditoryFrontEndDepKS
         blockCreator;
     end
     
-    methods (Abstract)
+    methods (Abstract, Access = protected)
         % a method through which the derived classes implement application
         % of features to the internal model instance given an AFE data block
         amlttpExecute( obj, afeBlock )

--- a/src/knowledge_sources/AbstractAMLTTPKS.m
+++ b/src/knowledge_sources/AbstractAMLTTPKS.m
@@ -1,0 +1,76 @@
+classdef AbstractAMLTTPKS < AuditoryFrontEndDepKS
+    
+    properties (SetAccess = private)
+        modelname;
+        model;                 % classifier model
+        featureCreator;
+        blockCreator;
+    end
+
+    methods
+        function obj = AbstractAMLTTPKS( modelName, modelDir, ppRemoveDc )
+            modelFileName = [modelDir filesep modelName];
+            v = load( db.getFile( [modelFileName '.model.mat'] ) );
+            if ~isa( v.featureCreator, 'FeatureCreators.Base' )
+                error( 'Loaded model''s featureCreator must implement FeatureCreators.Base.' );
+            end
+            afeRequests = v.featureCreator.getAFErequests();
+%             if nargin > 2 && pp_bNormalizeRMS
+%                 for ii = 1 : numel( afeRequests )
+%                     afeRequests{ii}.params.replaceParameters( ...
+%                                    genParStruct( 'pp_bNormalizeRMS', pp_bNormalizeRMS ) );
+%                 end
+%             end
+            if nargin > 2 && ppRemoveDc
+                for ii = 1 : numel( afeRequests )
+                    afeRequests{ii}.params.replaceParameters( ...
+                                   genParStruct( 'pp_bRemoveDC', ppRemoveDc ) );
+                end
+            end
+            obj = obj@AuditoryFrontEndDepKS( afeRequests );
+            obj.featureCreator = v.featureCreator;
+            obj.initBlockCreator(v);
+            obj.initModel(v);
+            obj.modelname = modelName;
+            obj.setInvocationFrequency(4);
+        end
+        
+        function initBlockCreator(obj, inputContent)
+            if isfield(inputContent, 'blockCreator')
+                if ~isa( inputContent.blockCreator, 'BlockCreators.Base' )
+                    error( 'Loaded model''s block creator must implement BeatureCreators.Base.' );
+                end
+            elseif isfield(inputContent, 'blockSize_s')
+                inputContent.blockCreator = ...
+                    BlockCreators.StandardBlockCreator( inputContent.blockSize_s, 0.5/3 );
+            else
+                % for models missing a block creator instance
+                inputContent.blockCreator = ...
+                    BlockCreators.StandardBlockCreator( 0.5, 0.5/3 );
+            end
+            obj.blockCreator = inputContent.blockCreator;
+        end
+        
+        function initModel(obj, inputContent)
+            if ~isa( inputContent.model, 'Models.Base' )
+                error( 'Loaded internal model must implement Models.Base.' );
+            end
+            obj.model = inputContent.model;
+        end
+        
+        function setInvocationFrequency( obj, newInvocationFrequency_Hz )
+            obj.invocationMaxFrequency_Hz = newInvocationFrequency_Hz;
+        end
+        
+        %% utility function for printing the obj
+        function s = char( obj )
+            s = [char@AuditoryFrontEndDepKS( obj ), '[', obj.modelname, ']'];
+        end
+        
+        %% execute functionality
+        function [b, wait] = canExecute( obj )
+            b = true;
+            wait = false;
+        end
+    end
+end

--- a/src/knowledge_sources/AbstractAMLTTPKS.m
+++ b/src/knowledge_sources/AbstractAMLTTPKS.m
@@ -72,5 +72,23 @@ classdef AbstractAMLTTPKS < AuditoryFrontEndDepKS
             b = true;
             wait = false;
         end
+        
+        function execute( obj )
+            % calls KS-specific execute imeplementations and notifies the blackboard system 
+            obj.prepAFEData();
+            obj.amlttpExecute();
+            notify( obj, 'KsFiredEvent', BlackboardEventData( obj.trigger.tmIdx ) );
+        end
+    end
+    
+    methods (Access = protected)
+        function prepAFEData( obj )    
+            afeData = obj.getAFEdata();
+            afeData = obj.blockCreator.cutDataBlock( afeData, obj.timeSinceTrigger );
+            obj.featureCreator.setAfeData( afeData );
+        end
+        
+        function amlttpExecute( obj )
+        end
     end
 end

--- a/src/knowledge_sources/AbstractAMLTTPKS.m
+++ b/src/knowledge_sources/AbstractAMLTTPKS.m
@@ -6,7 +6,13 @@ classdef AbstractAMLTTPKS < AuditoryFrontEndDepKS
         featureCreator;
         blockCreator;
     end
-
+    
+    methods (Abstract)
+        % a method through which the derived classes implement application
+        % of features to the internal model instance given an AFE data block
+        amlttpExecute( obj, afeBlock )
+    end
+    
     methods
         function obj = AbstractAMLTTPKS( modelName, modelDir, ppRemoveDc )
             modelFileName = [modelDir filesep modelName];
@@ -75,20 +81,20 @@ classdef AbstractAMLTTPKS < AuditoryFrontEndDepKS
         
         function execute( obj )
             % calls KS-specific execute imeplementations and notifies the blackboard system 
-            obj.prepAFEData();
-            obj.amlttpExecute();
+            afeBlock = obj.cutAFEBlock();
+            obj.amlttpExecute( afeBlock );
             notify( obj, 'KsFiredEvent', BlackboardEventData( obj.trigger.tmIdx ) );
+        end
+        
+        function delete( obj )
         end
     end
     
     methods (Access = protected)
-        function prepAFEData( obj )    
+        function afeData = cutAFEBlock( obj )
+            %% cut and retrieve most recent block of AFE data
             afeData = obj.getAFEdata();
             afeData = obj.blockCreator.cutDataBlock( afeData, obj.timeSinceTrigger );
-            obj.featureCreator.setAfeData( afeData );
-        end
-        
-        function amlttpExecute( obj )
         end
     end
 end

--- a/src/knowledge_sources/IdentityKS.m
+++ b/src/knowledge_sources/IdentityKS.m
@@ -1,64 +1,13 @@
-classdef IdentityKS < AuditoryFrontEndDepKS
-    
+classdef IdentityKS < AbstractAMLTTPKS
+    % IdentityKS drives sound identification 
+    % deployment system
     properties (SetAccess = private)
-        modelname;
-        model;                 % classifier model
-        featureCreator;
-        blockCreator;
     end
 
     methods
         function obj = IdentityKS( modelName, modelDir, ppRemoveDc )
-            modelFileName = [modelDir filesep modelName];
-            v = load( db.getFile( [modelFileName '.model.mat'] ) );
-            if ~isa( v.featureCreator, 'FeatureCreators.Base' )
-                error( 'Loaded model''s featureCreator must implement FeatureCreators.Base.' );
-            end
-            afeRequests = v.featureCreator.getAFErequests();
-%             if nargin > 2 && pp_bNormalizeRMS
-%                 for ii = 1 : numel( afeRequests )
-%                     afeRequests{ii}.params.replaceParameters( ...
-%                                    genParStruct( 'pp_bNormalizeRMS', pp_bNormalizeRMS ) );
-%                 end
-%             end
-            if nargin > 2 && ppRemoveDc
-                for ii = 1 : numel( afeRequests )
-                    afeRequests{ii}.params.replaceParameters( ...
-                                   genParStruct( 'pp_bRemoveDC', ppRemoveDc ) );
-                end
-            end
-            obj = obj@AuditoryFrontEndDepKS( afeRequests );
-            obj.featureCreator = v.featureCreator;
-            if isfield(v, 'blockCreator')
-                if ~isa( v.blockCreator, 'BlockCreators.Base' )
-                    error( 'Loaded model''s block creator must implement BeatureCreators.Base.' );
-                end
-            elseif isfield(v, 'blockSize_s')
-                v.blockCreator = BlockCreators.StandardBlockCreator( v.blockSize_s, 0.5/3 );
-            else
-                % for models missing a block creator instance
-                v.blockCreator = BlockCreators.StandardBlockCreator( 0.5, 0.5/3 );
-            end
-            obj.blockCreator = v.blockCreator;
-            obj.model = v.model;
-            obj.modelname = modelName;
-            obj.invocationMaxFrequency_Hz = 4;
-        end
-        
-        function setInvocationFrequency( obj, newInvocationFrequency_Hz )
-            % Youssef @Ivo: wieso nicht im Abstract Class?
-            obj.invocationMaxFrequency_Hz = newInvocationFrequency_Hz;
-        end
-        
-        %% utility function for printing the obj
-        function s = char( obj )
-            s = [char@AuditoryFrontEndDepKS( obj ), '[', obj.modelname, ']'];
-        end
-        
-        %% execute functionality
-        function [b, wait] = canExecute( obj )
-            b = true;
-            wait = false;
+            obj@AbstractAMLTTPKS( modelName, modelDir, ppRemoveDc );
+            obj.setInvocationFrequency(4);
         end
         
         function execute( obj )

--- a/src/knowledge_sources/IdentityKS.m
+++ b/src/knowledge_sources/IdentityKS.m
@@ -9,12 +9,10 @@ classdef IdentityKS < AbstractAMLTTPKS
             obj@AbstractAMLTTPKS( modelName, modelDir, ppRemoveDc );
             obj.setInvocationFrequency(4);
         end
-        
-        function execute( obj )
-            afeData = obj.getAFEdata();
-            afeData = obj.blockCreator.cutDataBlock( afeData, obj.timeSinceTrigger );
-            
-            obj.featureCreator.setAfeData( afeData );
+    end
+    
+    methods (Access = protected)
+        function amlttpExecute( obj )
             x = obj.featureCreator.constructVector();
             [d, score] = obj.model.applyModel( x{1} );
             
@@ -23,7 +21,6 @@ classdef IdentityKS < AbstractAMLTTPKS
             identHyp = IdentityHypothesis( ...
                 obj.modelname, score(1), d(1), obj.blockCreator.blockSize_s );
             obj.blackboard.addData( 'identityHypotheses', identHyp, true, obj.trigger.tmIdx );
-            notify( obj, 'KsFiredEvent', BlackboardEventData( obj.trigger.tmIdx ) );
         end
     end
 end

--- a/src/knowledge_sources/IdentityKS.m
+++ b/src/knowledge_sources/IdentityKS.m
@@ -12,7 +12,8 @@ classdef IdentityKS < AbstractAMLTTPKS
     end
     
     methods (Access = protected)
-        function amlttpExecute( obj )
+        function amlttpExecute( obj, afeBlock )
+            obj.featureCreator.setAfeData( afeBlock );
             x = obj.featureCreator.constructVector();
             [d, score] = obj.model.applyModel( x{1} );
             

--- a/src/knowledge_sources/IdentityLocationKS.m
+++ b/src/knowledge_sources/IdentityLocationKS.m
@@ -1,4 +1,4 @@
-classdef IdentityLocationKS < IdentityKS
+classdef IdentityLocationKS < AbstractAMLTTPKS
     
     properties (SetAccess = private)
         classnames;
@@ -7,12 +7,17 @@ classdef IdentityLocationKS < IdentityKS
 
     methods
         function obj = IdentityLocationKS( modelName, modelDir )
-            obj = obj@IdentityKS( modelName, modelDir );
+            obj = obj@AbstractAMLTTPKS( modelName, modelDir );
             modelFileName = fullfile(modelDir, modelName);
             v = load( [modelFileName '.model.mat'] );
             obj.classnames = v.classnames;
             obj.azimuths = v.azimuths;
             obj.model.initNet(v.modelDir, v.fname_net_def, v.fname_weights);
+        end
+        
+        function initModel(obj, inputContent)
+            % skip check for Models.Base
+            obj.model = inputContent.model;
         end
         
         function execute( obj )

--- a/src/knowledge_sources/IdentityLocationKS.m
+++ b/src/knowledge_sources/IdentityLocationKS.m
@@ -19,14 +19,11 @@ classdef IdentityLocationKS < AbstractAMLTTPKS
             % skip check for Models.Base
             obj.model = inputContent.model;
         end
-        
-        function execute( obj )
-
-        end
     end
     
     methods (Access = protected)
-        function amlttpExecute( obj )
+        function amlttpExecute( obj, afeBlock )
+            obj.featureCreator.setAfeData( afeBlock );
             x = obj.featureCreator.constructVector();
             
             [blobs_in, blobs_in_names] = obj.reshape2Blob( x{1}, x{2} );

--- a/src/knowledge_sources/IdentityLocationKS.m
+++ b/src/knowledge_sources/IdentityLocationKS.m
@@ -21,15 +21,16 @@ classdef IdentityLocationKS < AbstractAMLTTPKS
         end
         
         function execute( obj )
-            afeData = obj.getAFEdata();
-            afeData = obj.blockCreator.cutDataBlock( afeData, obj.timeSinceTrigger );
-            
-            obj.featureCreator.setAfeData( afeData );
+
+        end
+    end
+    
+    methods (Access = protected)
+        function amlttpExecute( obj )
             x = obj.featureCreator.constructVector();
             
             [blobs_in, blobs_in_names] = obj.reshape2Blob( x{1}, x{2} );
             [d, score] = obj.model.applyModel( {blobs_in, blobs_in_names} );
-            
             blobs_out_names = fieldnames(score);
             score_blob = score.(blobs_out_names{1}); % use only first one
             d_blob = d.(blobs_out_names{1}); % use only first one
@@ -47,12 +48,9 @@ classdef IdentityLocationKS < AbstractAMLTTPKS
                     currentHeadOrientation, ...
                     obj.azimuths, loc_probs, loc_decisions );
                 obj.blackboard.addData( 'identityHypotheses', hyp, true, obj.trigger.tmIdx );
-                notify( obj, 'KsFiredEvent', BlackboardEventData( obj.trigger.tmIdx ) );
             end % classnames
         end
-    end
     
-    methods (Access = protected)        
         function [x_feat, feature_type_names] = reshape2Blob(obj, x, featureNames)
             % twoears2Blob  reshape feature and ground truth vectors into 4-D Blob for caffe
             %   For the feature vector x it expects a shape of (N x D)

--- a/src/knowledge_sources/NumberOfSourcesKS.m
+++ b/src/knowledge_sources/NumberOfSourcesKS.m
@@ -8,8 +8,10 @@ classdef NumberOfSourcesKS < AbstractAMLTTPKS
             obj@AbstractAMLTTPKS( modelName, modelDir, ppRemoveDc );
             obj.setInvocationFrequency(4);
         end
-        
-        function execute( obj )
+    end
+    
+    methods (Access = protected)
+        function prepAFEData( obj )    
             afeData = obj.getAFEdata();
             afeData = obj.blockCreator.cutDataBlock( afeData, obj.timeSinceTrigger );
             
@@ -18,6 +20,9 @@ classdef NumberOfSourcesKS < AbstractAMLTTPKS
             afeData = DataProcs.DnnLocKsWrapper.addLocData( afeData, locHypos.data );
             
             obj.featureCreator.setAfeData( afeData );
+        end
+        
+        function amlttpExecute( obj )
             x = obj.featureCreator.constructVector();
             [d, score] = obj.model.applyModel( x{1} );
             d = round( d(1) );
@@ -26,7 +31,6 @@ classdef NumberOfSourcesKS < AbstractAMLTTPKS
             identHyp = NumberOfSourcesHypothesis( ...
                 obj.modelname, score(1), d, obj.blockCreator.blockSize_s );
             obj.blackboard.addData( 'NumberOfSourcesHypotheses', identHyp, true, obj.trigger.tmIdx );
-            notify( obj, 'KsFiredEvent', BlackboardEventData( obj.trigger.tmIdx ) );
         end
     end
 end

--- a/src/knowledge_sources/NumberOfSourcesKS.m
+++ b/src/knowledge_sources/NumberOfSourcesKS.m
@@ -1,57 +1,12 @@
-classdef NumberOfSourcesKS < AuditoryFrontEndDepKS
+classdef NumberOfSourcesKS < AbstractAMLTTPKS
     
     properties (SetAccess = private)
-        modelname;
-        model;                 % classifier model
-        featureCreator;
-        blockCreator;
     end
 
     methods
         function obj = NumberOfSourcesKS( modelName, modelDir, ppRemoveDc )
-            modelFileName = [modelDir filesep modelName];
-            v = load( db.getFile( [modelFileName '.model.mat'] ) );
-            if ~isa( v.featureCreator, 'FeatureCreators.Base' )
-                error( 'Loaded model''s featureCreator must implement FeatureCreators.Base.' );
-            end
-            afeRequests = v.featureCreator.getAFErequests();
-            if nargin > 2 && ppRemoveDc
-                for ii = 1 : numel( afeRequests )
-                    afeRequests{ii}.params.replaceParameters( ...
-                                   genParStruct( 'pp_bRemoveDC', ppRemoveDc ) );
-                end
-            end
-            obj = obj@AuditoryFrontEndDepKS( afeRequests );
-            obj.featureCreator = v.featureCreator;
-            if isfield(v, 'blockCreator')
-                if ~isa( v.blockCreator, 'BlockCreators.Base' )
-                    error( 'Loaded model''s block creator must implement BeatureCreators.Base.' );
-                end
-            elseif isfield(v, 'blockSize_s')
-                v.blockCreator = BlockCreators.StandardBlockCreator( v.blockSize_s, 0.5/3 );
-            else
-                % for models missing a block creator instance
-                v.blockCreator = BlockCreators.StandardBlockCreator( 0.5, 0.5/3 );
-            end
-            obj.blockCreator = v.blockCreator;
-            obj.model = v.model;
-            obj.modelname = modelName;
-            obj.invocationMaxFrequency_Hz = 4;
-        end
-        
-        function setInvocationFrequency( obj, newInvocationFrequency_Hz )
-            obj.invocationMaxFrequency_Hz = newInvocationFrequency_Hz;
-        end
-        
-        %% utility function for printing the obj
-        function s = char( obj )
-            s = [char@AuditoryFrontEndDepKS( obj ), '[', obj.modelname, ']'];
-        end
-        
-        %% execute functionality
-        function [b, wait] = canExecute( obj )
-            b = true;
-            wait = false;
+            obj@AbstractAMLTTPKS( modelName, modelDir, ppRemoveDc );
+            obj.setInvocationFrequency(4);
         end
         
         function execute( obj )

--- a/src/knowledge_sources/NumberOfSourcesKS.m
+++ b/src/knowledge_sources/NumberOfSourcesKS.m
@@ -10,19 +10,14 @@ classdef NumberOfSourcesKS < AbstractAMLTTPKS
         end
     end
     
-    methods (Access = protected)
-        function prepAFEData( obj )    
-            afeData = obj.getAFEdata();
-            afeData = obj.blockCreator.cutDataBlock( afeData, obj.timeSinceTrigger );
-            
+    methods (Access = protected)        
+        function amlttpExecute( obj, afeBlock )
             locHypos = obj.blackboard.getLastData( 'sourcesAzimuthsDistributionHypotheses' );
             assert( numel( locHypos.data ) == 1 );
-            afeData = DataProcs.DnnLocKsWrapper.addLocData( afeData, locHypos.data );
+            afeBlock = DataProcs.DnnLocKsWrapper.addLocData( afeBlock, locHypos.data );
             
-            obj.featureCreator.setAfeData( afeData );
-        end
-        
-        function amlttpExecute( obj )
+            obj.featureCreator.setAfeData( afeBlock );
+            
             x = obj.featureCreator.constructVector();
             [d, score] = obj.model.applyModel( x{1} );
             d = round( d(1) );

--- a/src/knowledge_sources/SegmentIdentityKS.m
+++ b/src/knowledge_sources/SegmentIdentityKS.m
@@ -12,8 +12,13 @@ classdef SegmentIdentityKS < AbstractAMLTTPKS
             obj@AbstractAMLTTPKS( modelName, modelDir, ppRemoveDc );
             obj.setInvocationFrequency(4);
         end
+    end
+    
+    methods (Access = protected)
+        function prepAFEData( obj )
+        end
         
-        function execute( obj )
+        function amlttpExecute( obj )
             afeData = obj.getAFEdata();
             afeData = obj.blockCreator.cutDataBlock( afeData, obj.timeSinceTrigger );
             
@@ -44,8 +49,6 @@ classdef SegmentIdentityKS < AbstractAMLTTPKS
                 identHyp, true, obj.trigger.tmIdx );
             % TODO: use joint LocIdHypo or add azm to IdHypo (then also
             % plot azm)
-            notify( obj, 'KsFiredEvent', ...
-                BlackboardEventData( obj.trigger.tmIdx ) );
         end
     end
     

--- a/src/knowledge_sources/SegmentIdentityKS.m
+++ b/src/knowledge_sources/SegmentIdentityKS.m
@@ -14,14 +14,8 @@ classdef SegmentIdentityKS < AbstractAMLTTPKS
         end
     end
     
-    methods (Access = protected)
-        function prepAFEData( obj )
-        end
-        
-        function amlttpExecute( obj )
-            afeData = obj.getAFEdata();
-            afeData = obj.blockCreator.cutDataBlock( afeData, obj.timeSinceTrigger );
-            
+    methods (Access = protected)        
+        function amlttpExecute( obj, afeBlock )
             mask = obj.blackboard.getLastData('segmentationHypotheses', ...
                 obj.trigger.tmIdx);
             % create masked copy of afeData
@@ -29,12 +23,12 @@ classdef SegmentIdentityKS < AbstractAMLTTPKS
             score = {};
             estSrcAzm = [];
             for ii = 1 : numel(mask.data)
-                afeData_masked = SegmentIdentityKS.maskAFEData( afeData, ...
+                afeBlock_masked = SegmentIdentityKS.maskAFEData( afeBlock, ...
                     mask.data(ii).softMask, ...
                     mask.data(ii).cfHz, ...
                     mask.data(ii).hopSize );
                 
-                obj.featureCreator.setAfeData( afeData_masked );
+                obj.featureCreator.setAfeData( afeBlock_masked );
                 x = obj.featureCreator.constructVector();
                 [d(ii), score{ii}] = obj.model.applyModel( x{1} );
                 estSrcAzm(ii) = mask.data(ii).refAzm;


### PR DESCRIPTION
new `AbstractAMLTTP` parent class for KSs that are driven by AMLTTP models (e.g. `IdentityKS`, `SegmentIdentityKS`, `NumberOfSourcesKS`, `IdentityLocationKS`)
The parent class takes care of reading the model input file and checking its content (`featureCreator',`blockCreator').
Derived classes implement the excute method and can override these checks.

This resolves #32 and is a followup to the discussion in #30 
