### PR TITLE
check flag instead of multiple isfield checks

### DIFF
--- a/src/knowledge_sources/StreamSegregationKS.m
+++ b/src/knowledge_sources/StreamSegregationKS.m
@@ -109,10 +109,9 @@ classdef StreamSegregationKS < AuditoryFrontEndDepKS
                 end
             else
                 locHypos = obj.blackboard.getLastData( 'locationHypothesis' );
-                isLocHyp = true;
-                if isempty( locHypos )
+                isLocHyp = ~isempty( locHypos );
+                if ~isLocHyp
                     locHypos = obj.blackboard.getLastData( 'sourcesAzimuthsDistributionHypotheses' );
-                    isLocHyp = false;
                 end
                 assert( numel( locHypos.data ) == 1 );
                 locData = locHypos.data;

--- a/src/knowledge_sources/StreamSegregationKS.m
+++ b/src/knowledge_sources/StreamSegregationKS.m
@@ -109,8 +109,10 @@ classdef StreamSegregationKS < AuditoryFrontEndDepKS
                 end
             else
                 locHypos = obj.blackboard.getLastData( 'locationHypothesis' );
+                isLocHyp = true;
                 if isempty( locHypos )
                     locHypos = obj.blackboard.getLastData( 'sourcesAzimuthsDistributionHypotheses' );
+                    isLocHyp = false;
                 end
                 assert( numel( locHypos.data ) == 1 );
                 locData = locHypos.data;
@@ -123,7 +125,7 @@ classdef StreamSegregationKS < AuditoryFrontEndDepKS
                     % segregating into 0 streams seems pointless
                 end
                 refAzm = zeros( 1, numAzimuths );
-                if isfield( locData, 'sourcesPosteriors' )
+                if isLocHyp
                     posteriors = locData.sourcesPosteriors;
                 else
                     posteriors = locData.sourcesDistribution;
@@ -139,7 +141,7 @@ classdef StreamSegregationKS < AuditoryFrontEndDepKS
                 [~, locPeaksSortedAzmIdxs] = sort( locPeaks, 'descend' );
                 locSortedAzmIdxs = locPeaksIdxs(locPeaksSortedAzmIdxs);
                 for azimuthIdx = 1 : numAzimuths
-                    if isfield( locData, 'sourceAzimuths' )
+                    if isLocHyp
                         refAzm(azimuthIdx) = wrapTo180( ...
                             locData.sourceAzimuths(locSortedAzmIdxs(azimuthIdx)) );
                     else


### PR DESCRIPTION
localizations data is either available in `LocationHypothesis` or `SourcesAzimuthsDistributionHypothesis` objects depending on which KS wrote the data to the blackboard.
StreamSegregation will try to use the polished `LocationHypothesis` data and will resort to the data stored as `SourcesAzimuthsDistributionHypothesis` if the former is not available.

Both Hypthesis classes don't share the exact attribute names, therefore several isfield() calls are made to access the correct properties. This PR replaces the isfield calls with checking a flag that is set, once it is determined which hypothesis class will be used.

Why do we need this? For some reason the isfield method returns false even though the property is available and accessible. I don't know why it wouldn't work in this particular case, but this avoids this odd behavior altogether.